### PR TITLE
comment out nonexisting rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
 
   <buildtool_export_depend>cmake</buildtool_export_depend>
 
-  <depend>FOONATHAN_MEMORY</depend>
+  <!--depend>FOONATHAN_MEMORY</depend-->
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

The `FOONATHAN_MEMORY` rosdep key doesnt exist in the rosdep database or as a package installing a package.xml so this causes [rosdep to fail](https://cloud.docker.com/u/osrf/repository/registry-1.docker.io/osrf/ros2/builds/d998183f-ed59-4838-ae25-da29af45cdc3) on this package