### PR TITLE
declare missing dependency on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license> <!-- The contents of this vendor package are Apache 2.0 -->
   <license>zlib License</license> <!-- foonathan/memory is licensed under the zlib License (https://github.com/foonathan/memory/blob/master/LICENSE) -->
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <buildtool_export_depend>cmake</buildtool_export_depend>
 


### PR DESCRIPTION
Since the package requires `git` to fetch the external project it must be declared in the manifest otherwise it might not be available.

Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__nightly-fastrtps_ubuntu_bionic_amd64&build=46)](http://build.ros2.org/view/Eci/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/46/)
After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__nightly-fastrtps_ubuntu_bionic_amd64&build=47)](http://build.ros2.org/view/Eci/job/Eci__nightly-fastrtps_ubuntu_bionic_amd64/47/)

@richiware