### PR TITLE
Fix patch for Windows Installer [7293]

### DIFF
--- a/CMakeLists.txt.patch
+++ b/CMakeLists.txt.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cf28169..16b6cdf 100644
+index c43485d..ee60bd9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -38,12 +38,12 @@ if(UNIX)
+@@ -35,13 +35,13 @@ if(UNIX)
  
  elseif(WIN32)
      set(FOONATHAN_MEMORY_INC_INSTALL_DIR "include/foonathan_memory")
--    set(FOONATHAN_MEMORY_RUNTIME_INSTALL_DIR   "bin") 
+-    set(FOONATHAN_MEMORY_RUNTIME_INSTALL_DIR   "bin")
 -    set(FOONATHAN_MEMORY_LIBRARY_INSTALL_DIR   "bin")
 -    set(FOONATHAN_MEMORY_ARCHIVE_INSTALL_DIR   "lib")
 -    set(FOONATHAN_MEMORY_FRAMEWORK_INSTALL_DIR "bin")
@@ -16,7 +16,9 @@ index cf28169..16b6cdf 100644
 +    set(FOONATHAN_MEMORY_FRAMEWORK_INSTALL_DIR "bin/INSTALLER_PLATFORM")
  
 -    set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "share/foonathan_memory/cmake")
+-    set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "share/foonathan_memory")
 +    set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "share/foonathan_memory-INSTALLER_PLATFORM/cmake")
-     set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "share/foonathan_memory")
++    set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "share/foonathan_memory-INSTALLER_PLATFORM")
      set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
  else()
+     message(FATAL_ERROR "Could not set install folders for this platform!")


### PR DESCRIPTION
Updating CMakeLists.txt.patch to account for recent changes on foonathan/memory
These changes are only necessary for the process of generating the installers of Fast-RTPS.