### PR TITLE
Enable linter and copyright tests to the package [7487]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 project(foonathan_memory_vendor VERSION "0.5.0")
 
 find_package(foonathan_memory QUIET)
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_copyright QUIET)
+find_package(ament_cmake_lint_cmake QUIET)
+find_package(ament_cmake_xmllint QUIET)
 
 if(NOT foonathan_memory_FOUND)
   ###############################################################################
@@ -87,11 +89,16 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion)
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
+  if(ament_cmake_copyright_FOUND)
+    ament_copyright()
+  endif()
+  if(ament_cmake_lint_cmake_FOUND)
+    ament_lint_cmake()
+  endif()
+  if(ament_cmake_xmllint_FOUND)
+    ament_xmllint()
+  endif()
 endif()
-
-ament_package()
 
 install(FILES
   package.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 project(foonathan_memory_vendor VERSION "0.5.0")
 
 find_package(foonathan_memory QUIET)
-find_package(ament_cmake_copyright QUIET)
-find_package(ament_cmake_lint_cmake QUIET)
-find_package(ament_cmake_xmllint QUIET)
 
 if(NOT foonathan_memory_FOUND)
   ###############################################################################
@@ -89,6 +86,9 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion)
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_copyright QUIET)
+  find_package(ament_cmake_lint_cmake QUIET)
+  find_package(ament_cmake_xmllint QUIET)
   if(ament_cmake_copyright_FOUND)
     ament_copyright()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(foonathan_memory_vendor VERSION "0.5.0")
 
 find_package(foonathan_memory QUIET)
+find_package(ament_cmake REQUIRED)
 
 if(NOT foonathan_memory_FOUND)
   ###############################################################################
@@ -11,16 +12,16 @@ if(NOT foonathan_memory_FOUND)
   # If set to true, this will cause all libraries to be built shared
   # unless the library was explicitly added as a static library.
   option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
-  
+
   if(BUILD_SHARED_LIBS)
     # Library will be statically created with PIC code
     list(APPEND extra_cmake_args -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
   endif()
-  
+
   if(DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()
-  
+
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     if(ANDROID)
@@ -49,12 +50,12 @@ if(NOT foonathan_memory_FOUND)
     endif()
   endif()
   include(ExternalProject)
-  
+
   if(INSTALLER_PLATFORM)
     set(PATCH_COMMAND_STR PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.patch && sed -i -e "s/INSTALLER_PLATFORM/${INSTALLER_PLATFORM}/g" CMakeLists.txt)
   endif()
 
-  ExternalProject_Add(foo_mem-ext
+  externalproject_add(foo_mem-ext
   GIT_REPOSITORY https://github.com/foonathan/memory.git
   GIT_TAG master
   TIMEOUT 600
@@ -69,7 +70,7 @@ if(NOT foonathan_memory_FOUND)
     -Wno-dev
     ${PATCH_COMMAND_STR}
   )
-  
+
   # The external project will install to the build folder, but we'll install that on make install.
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/foo_mem_ext_prj_install/
   DESTINATION ${CMAKE_INSTALL_PREFIX})
@@ -84,6 +85,13 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/foonathan_memory_vendorConfig-version.cmake"
   COMPATIBILITY AnyNewerVersion)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
 
 install(FILES
   package.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/package.xml
+++ b/package.xml
@@ -16,10 +16,11 @@
   <buildtool_export_depend>cmake</buildtool_export_depend>
 
   <!--depend>FOONATHAN_MEMORY</depend-->
-
-  <test_depend>ament_cmake</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  
+  <test_depend>ament_package</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,10 @@
 
   <!--depend>FOONATHAN_MEMORY</depend-->
 
+  <test_depend>ament_cmake</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
Enable ament_common linter and copyright tests.
Added contributing.md file to pass these tests. 
Changed uppercase cmake command to lowercase to match linter configuration.

Signed-off-by: Jorge J. Perez <jjperez@ekumenlabs.com>