### PR TITLE
Add dependency required to set BUILD_TESTING env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/foonathan_memory_vendorConfig-version.cmake"
   COMPATIBILITY AnyNewerVersion)
 
+find_package(ament_cmake_test QUIET)
 if(BUILD_TESTING)
   find_package(ament_cmake_copyright QUIET)
   find_package(ament_cmake_lint_cmake QUIET)

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
 
   <!--depend>FOONATHAN_MEMORY</depend-->
   
-  <test_depend>ament_package</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_test</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_package</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_test</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>


### PR DESCRIPTION
This is a fix required for #19 to work completely. The BUILD_TESTING variable was not set, and the code calling the linters was not entered. Didn't note this behavior before because CMake saved this variable on the build folder of the package, and was working. However, in a clean environment, this addition is necessary to actually run the tests. 

Added optional dependency for ament_cmake_test.

Please check this out @MiguelCompany

Signed-off-by: Jorge J. Perez <jjperez@ekumenlabs.com>