### PR TITLE
Use a specific revision of foonathan/memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT foonathan_memory_FOUND)
 
   externalproject_add(foo_mem-ext
   GIT_REPOSITORY https://github.com/foonathan/memory.git
-  GIT_TAG master
+  GIT_TAG c619113
   TIMEOUT 600
   # Avoid the update (git pull) and so the recompilation of foonathan_memory library each time.
   UPDATE_COMMAND ""


### PR DESCRIPTION
There have been recent regressions introduced in the `eloquent` release nightly CI for jobs that depend on `foonathan_memory_vendor`.  It was found that this vendor package always pulling the `master` version of `foonathan/memory` introduced the regression.

This makes the vendor package use a specific revision from slightly before the regression was introduced.

Signed-off-by: Michael Carroll <michael@openrobotics.org>