### PR TITLE
Prepare 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(foonathan_memory_vendor VERSION "0.6.0")
+project(foonathan_memory_vendor VERSION "1.0.0")
 
 find_package(foonathan_memory QUIET)
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -14,7 +14,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### Version Stability [1.ii]
 
-`foonathan_memory_vendor` is not yet at a stable version, i.e. `>= 1.0.0`.
+`foonathan_memory_vendor` is at or above a stable version, i.e. `>= 1.0.0`.
 
 ### Public API Declaration [1.iii]
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>foonathan_memory_vendor</name>
-  <version>0.6.0</version>
+  <version>1.0.0</version>
   <description>Foonathan/memory vendor package for Fast-RTPS.</description>
   <maintainer email="miguelcompany@eprosima.com">Miguel Company</maintainer>
   <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>


### PR DESCRIPTION
There are no code changes since the 0.6.0 release. This version bump serves to commit to the "public API" such as it is for this vendor package and is part of the work to get packages in the ROS 2 core up to a 1.0-level commitment.