### PR TITLE
Add options instead of forcing them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ if(NOT foonathan_memory_FOUND)
   option(BUILD_MEMORY_TESTS "Build memory tests" OFF)
   # Option to build memory tools
   option(BUILD_MEMORY_TOOLS "Build memory tools" ON)
+  
+  # Validate option dependency
+  if( (NOT BUILD_MEMORY_TOOLS) AND (BUILD_MEMORY_EXAMPLES OR BUILD_MEMORY_TESTS) )
+    message(FATAL_ERROR
+      "BUILD_MEMORY_TOOLS is required when BUILD_MEMORY_EXAMPLES or BUILD_MEMORY_TESTS are set")
+  endif()
 
   if(BUILD_SHARED_LIBS)
     # Library will be statically created with PIC code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ if(NOT foonathan_memory_FOUND)
   # unless the library was explicitly added as a static library.
   option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 
+  # Option to build memory examples
+  option(BUILD_MEMORY_EXAMPLES "Build memory examples" OFF)
+  # Option to build memory tests
+  option(BUILD_MEMORY_TESTS "Build memory tests" OFF)
   # Option to build memory tools
   option(BUILD_MEMORY_TOOLS "Build memory tools" ON)
 
@@ -64,8 +68,8 @@ if(NOT foonathan_memory_FOUND)
   # Avoid the update (git pull) and so the recompilation of foonathan_memory library each time.
   UPDATE_COMMAND ""
   CMAKE_ARGS
-    -DFOONATHAN_MEMORY_BUILD_EXAMPLES=OFF
-    -DFOONATHAN_MEMORY_BUILD_TESTS=OFF
+    -DFOONATHAN_MEMORY_BUILD_EXAMPLES=${BUILD_MEMORY_EXAMPLES}
+    -DFOONATHAN_MEMORY_BUILD_TESTS=${BUILD_MEMORY_TESTS}
     -DFOONATHAN_MEMORY_BUILD_TOOLS=${BUILD_MEMORY_TOOLS}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/foo_mem_ext_prj_install
     ${extra_cmake_args}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ if(NOT foonathan_memory_FOUND)
   # unless the library was explicitly added as a static library.
   option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 
+  # Option to build memory tools
+  option(BUILD_MEMORY_TOOLS "Build memory tools" ON)
+
   if(BUILD_SHARED_LIBS)
     # Library will be statically created with PIC code
     list(APPEND extra_cmake_args -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
@@ -63,7 +66,7 @@ if(NOT foonathan_memory_FOUND)
   CMAKE_ARGS
     -DFOONATHAN_MEMORY_BUILD_EXAMPLES=OFF
     -DFOONATHAN_MEMORY_BUILD_TESTS=OFF
-    -DFOONATHAN_MEMORY_BUILD_TOOLS=ON
+    -DFOONATHAN_MEMORY_BUILD_TOOLS=${BUILD_MEMORY_TOOLS}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/foo_mem_ext_prj_install
     ${extra_cmake_args}
     -Wno-dev


### PR DESCRIPTION
When cross-compiling for RPi2, I got this error:

```
HEAD is now at c619113 Whitespace clean up (#70)
Submodule 'cmake/comp' (https://github.com/foonathan/compatibility.git) registered for path 'cmake/comp'
Cloning into '/root/ws/build/foonathan_memory_vendor/foo_mem-ext-prefix/src/foo_mem-ext/cmake/comp'...
/bin/sh: 1: ../tool/nodesize_dbg: not found
make[5]: *** [src/container_node_sizes_impl.hpp] Error 127
make[4]: *** [src/CMakeFiles/foonathan_memory.dir/all] Error 2
make[3]: *** [all] Error 2
make[2]: *** [foo_mem-ext-prefix/src/foo_mem-ext-stamp/foo_mem-ext-build] Error 2
make[1]: *** [CMakeFiles/foo_mem-ext.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< foonathan_memory_vendor	[ Exited with code 2 ]
```
which lead me to add the option to not build the memory tools.

Signed-off-by: Mauro <mpasserino@irobot.com>