### PR TITLE
Fixed test dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ if(NOT foonathan_memory_FOUND)
 
   if(INSTALLER_PLATFORM)
     set(PATCH_COMMAND_STR PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.patch && sed -i -e "s/INSTALLER_PLATFORM/${INSTALLER_PLATFORM}/g" CMakeLists.txt)
+  elseif(BUILD_MEMORY_TESTS)
+    set(PATCH_COMMAND_STR PATCH_COMMAND git cherry-pick 09b884c18abb314bfa678df27141a4dcad71c4ba)
   endif()
 
   externalproject_add(foo_mem-ext


### PR DESCRIPTION
Nightlies have failed to build twice in a row. An example can be found [here](http://jenkins.eprosima.com:8080/view/Nightly%20Foonathan%20Memory/job/nightly_foonathan_memory_master_linux/28)

A 404 error is shown while trying to get `raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch2/catch.hpp`. Seems like the master branch has been removed on `Catch2`, which is the framework used for testing.

This [commit](https://github.com/foonathan/memory/commit/09b884c18abb314bfa678df27141a4dcad71c4ba) on the upstream repository fixed the dependency, but we are fixed to a previous commit here, so with this PR we cherry pick the solution when we want to execute the upstream tests on the commit we are fixed to.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>