### PR TITLE
Use git apply instead of cherry-pick

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ if(NOT foonathan_memory_FOUND)
   if(INSTALLER_PLATFORM)
     set(PATCH_COMMAND_STR PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.patch && sed -i -e "s/INSTALLER_PLATFORM/${INSTALLER_PLATFORM}/g" CMakeLists.txt)
   elseif(BUILD_MEMORY_TESTS)
-    set(PATCH_COMMAND_STR PATCH_COMMAND git cherry-pick 09b884c18abb314bfa678df27141a4dcad71c4ba)
+    # This could be removed whenever we change the GIT_TAG from c619113 to anything above 09b884c
+    set(PATCH_COMMAND_STR PATCH_COMMAND curl https://github.com/foonathan/memory/commit/09b884c18abb314bfa678df27141a4dcad71c4ba.diff | git apply -)
   endif()
 
   externalproject_add(foo_mem-ext


### PR DESCRIPTION
Follow-up of #41 

As git cherry-pick creates a commit, it requires git user configuration to be set.

This PR changes this for getting the diff of the commit with `curl` and using git apply with the downloaded diff.

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>