### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,13 @@ if(NOT foonathan_memory_FOUND)
   include(ExternalProject)
 
   if(INSTALLER_PLATFORM)
-    set(PATCH_COMMAND_STR PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.patch && sed -i -e "s/INSTALLER_PLATFORM/${INSTALLER_PLATFORM}/g" CMakeLists.txt)
+    set(PATCH_COMMAND_STR PATCH_COMMAND
+      git apply ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt.patch &&
+      sed -i -e "s/INSTALLER_PLATFORM/${INSTALLER_PLATFORM}/g" CMakeLists.txt)
   elseif(BUILD_MEMORY_TESTS)
     # This could be removed whenever we change the GIT_TAG from c619113 to anything above 09b884c
-    set(PATCH_COMMAND_STR PATCH_COMMAND curl https://github.com/foonathan/memory/commit/09b884c18abb314bfa678df27141a4dcad71c4ba.diff | git apply -)
+    set(PATCH_COMMAND_STR PATCH_COMMAND
+      curl https://github.com/foonathan/memory/commit/09b884c18abb314bfa678df27141a4dcad71c4ba.diff | git apply -)
   endif()
 
   externalproject_add(foo_mem-ext

--- a/foonathan_memory-config.cmake
+++ b/foonathan_memory-config.cmake
@@ -14,15 +14,19 @@
 
 if(MSVC_VERSION EQUAL 1900)
     if(CMAKE_CL_64)
-        include("${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-x64Win64VS2015/cmake/foonathan_memory-config.cmake")
+        include(
+          "${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-x64Win64VS2015/cmake/foonathan_memory-config.cmake")
     else()
-        include("${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-i86Win32VS2015/cmake/foonathan_memory-config.cmake")
+        include(
+          "${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-i86Win32VS2015/cmake/foonathan_memory-config.cmake")
     endif()
 elseif(MSVC_VERSION GREATER 1900)
     if(CMAKE_CL_64)
-        include("${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-x64Win64VS2017/cmake/foonathan_memory-config.cmake")
+        include(
+          "${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-x64Win64VS2017/cmake/foonathan_memory-config.cmake")
     else()
-        include("${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-i86Win32VS2017/cmake/foonathan_memory-config.cmake")
+        include(
+          "${CMAKE_CURRENT_LIST_DIR}/../share/foonathan_memory-i86Win32VS2017/cmake/foonathan_memory-config.cmake")
     endif()
 else()
     message(FATAL_ERROR "Not supported version of Visual Studio")


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)