### PR TITLE
Prepare 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,20 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package foonathan_memory_vendor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.1.0 (2021-05-18)
+------------------
+* QD Security Vulnerability Declaration: REP 2006 (`#34 <https://github.com/eProsima/foonathan_memory_vendor/pull/34>`_)
+* Update vendor package Quality Declaration to QL3 (`#35 <https://github.com/eProsima/foonathan_memory_vendor/pull/35>`_)
+* Add options instead of forcing them (`#32 <https://github.com/eProsima/foonathan_memory_vendor/pull/32>`_)
+    * Add build memory tools option
+    * Add options for building tests and examples
+    * Added option dependency validation
+* Fixed linter issues (`#38 <https://github.com/eProsima/foonathan_memory_vendor/pull/38>`_)
+* Point to upstream quality declaration and bump to level 2 (`#39 <https://github.com/eProsima/foonathan_memory_vendor/pull/39>`_)
+* Fixed test dependency (`#41 <https://github.com/eProsima/foonathan_memory_vendor/pull/41>`_)
+* Use git apply instead of cherry-pick (`#42 <https://github.com/eProsima/foonathan_memory_vendor/pull/42>`_)
+* Shorten some excessively long lines of CMake (`#44 <https://github.com/eProsima/foonathan_memory_vendor/pull/44>`_)
+* Update package scripts for VS2019 (`#45 <https://github.com/eProsima/foonathan_memory_vendor/pull/45>`_)
+* Drop support for VS2015 (`#46 <https://github.com/eProsima/foonathan_memory_vendor/pull/46>`_)
+* Contributors: Chris Lalancette, Michel Hidalgo, Mauro Passerino, Miguel Company, Louise Poubel, Scott K Logan, Miguel Barro

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,10 @@ Changelog for package foonathan_memory_vendor
 * QD Security Vulnerability Declaration: REP 2006 (`#34 <https://github.com/eProsima/foonathan_memory_vendor/pull/34>`_)
 * Update vendor package Quality Declaration to QL3 (`#35 <https://github.com/eProsima/foonathan_memory_vendor/pull/35>`_)
 * Add options instead of forcing them (`#32 <https://github.com/eProsima/foonathan_memory_vendor/pull/32>`_)
-    * Add build memory tools option
-    * Add options for building tests and examples
-    * Added option dependency validation
+
+  * Add build memory tools option
+  * Add options for building tests and examples
+  * Added option dependency validation
 * Fixed linter issues (`#38 <https://github.com/eProsima/foonathan_memory_vendor/pull/38>`_)
 * Point to upstream quality declaration and bump to level 2 (`#39 <https://github.com/eProsima/foonathan_memory_vendor/pull/39>`_)
 * Fixed test dependency (`#41 <https://github.com/eProsima/foonathan_memory_vendor/pull/41>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(foonathan_memory_vendor VERSION "1.0.0")
+project(foonathan_memory_vendor VERSION "1.1.0")
 
 find_package(foonathan_memory QUIET)
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>foonathan_memory_vendor</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Foonathan/memory vendor package for Fast-RTPS.</description>
   <maintainer email="miguelcompany@eprosima.com">Miguel Company</maintainer>
   <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>


### PR DESCRIPTION
There have been [several improvements](https://github.com/eProsima/foonathan_memory_vendor/compare/v1.0.0...master) since 1.0.0 was released, so I think bumping the version number makes sense.