### PR TITLE
Build as static by default [13951]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ if(NOT foonathan_memory_FOUND)
   option(BUILD_MEMORY_TESTS "Build memory tests" OFF)
   # Option to build memory tools
   option(BUILD_MEMORY_TOOLS "Build memory tools" ON)
+  # Option for position independence
+  option(CMAKE_POSITION_INDEPENDENT_CODE "Enable position independence" ON)
 
   # Validate option dependency
   if((NOT BUILD_MEMORY_TOOLS) AND (BUILD_MEMORY_EXAMPLES OR BUILD_MEMORY_TESTS))
@@ -27,16 +29,10 @@ if(NOT foonathan_memory_FOUND)
   endif()
 
   # Propagate BUILD_SHARED_LIBS
-  if(DEFINED BUILD_SHARED_LIBS)
-    list(APPEND extra_cmake_args -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
-  endif()
+  list(APPEND extra_cmake_args -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
 
   # Propagate CMAKE_POSITION_INDEPENDENT_CODE
-  if(DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
-    list(APPEND extra_cmake_args -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE})
-  elseif(BUILD_SHARED_LIBS)
-    list(APPEND extra_cmake_args -DCMAKE_POSITION_INDEPENDENT_CODE=ON})
-  endif()
+  list(APPEND extra_cmake_args -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE})
 
   if(DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT foonathan_memory_FOUND)
   # Global flag to cause add_library() to create shared libraries if on.
   # If set to true, this will cause all libraries to be built shared
   # unless the library was explicitly added as a static library.
-  option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
+  option(BUILD_SHARED_LIBS "Create shared libraries by default" OFF)
 
   # Option to build memory examples
   option(BUILD_MEMORY_EXAMPLES "Build memory examples" OFF)


### PR DESCRIPTION
Upstream is not exporting some symbols when building a dynamic library, which leads to linking errors on Windows platforms. This PR sets the vendor to build `memory` as a static library with position independent code as default, letting the user configure both `BUILD_SHARED_LIBS` and `CMAKE_POSITION_INDEPENDENT_CODE` as CMake options. Once `memory` is ready to be built as a DLL, then we can consider changing the default value for `BUILD_SHARED_LIBS`