### PR TITLE
[17047] Update installers patch to 0.7-3.

### DIFF
--- a/CMakeLists.txt.patch
+++ b/CMakeLists.txt.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e765e39..b746e8e 100644
+index ddbc459..ce03503 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -31,13 +31,13 @@ if(UNIX OR VXWORKS)
+@@ -30,13 +30,13 @@ if(UNIX OR VXWORKS)
      set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/foonathan_memory")
  elseif(WIN32)
      set(FOONATHAN_MEMORY_INC_INSTALL_DIR "include/foonathan_memory")
@@ -20,9 +20,9 @@ index e765e39..b746e8e 100644
 +    set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "share/foonathan_memory-INSTALLER_PLATFORM/cmake")
 +    set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "share/foonathan_memory-INSTALLER_PLATFORM")
      set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
  else()
-     message(FATAL_ERROR "Could not set install folders for this platform!")
-@@ -65,4 +65,11 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE" "${CMAKE_CURRENT_SOURCE_DIR}
+@@ -66,4 +66,11 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE" "${CMAKE_CURRENT_SOURCE_DIR}
  install(EXPORT foonathan_memoryTargets DESTINATION ${FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR}
                                         FILE foonathan_memory-config.cmake)
  


### PR DESCRIPTION
In order for the Fast DDS Windows Installer job to succeed, the patch to the CMakelists.txt file should be updated.

Running check [here](http://jenkins.eprosima.com:8080/job/FastRTPS%20Installer%20Windows/408)