### PR TITLE
Change mechanism to find an installation of foonathan_memory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package foonathan_memory_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.3.2 (2023-10-24)
+------------------
+* Improve mechanism to find an installation of foonathan_memory (#67)
+
 1.3.1 (2023-05-10)
 ------------------
 * Added support for QNX 7.1 build (#65)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(foonathan_memory_vendor VERSION "1.3.1")
+project(foonathan_memory_vendor VERSION "1.3.2")
 
 execute_process(
     COMMAND ${CMAKE_COMMAND} --find-package -DNAME=foonathan_memory -DCOMPILER_ID=$<IF:$<BOOL:${WIN32}>,MSVC,GNU> -DLANGUAGE=CXX -DMODE=EXIST -DCMAKE_FIND_DEBUG_MODE=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 project(foonathan_memory_vendor VERSION "1.3.1")
 
-find_package(foonathan_memory QUIET)
+execute_process(
+    COMMAND ${CMAKE_COMMAND} --find-package -DNAME=foonathan_memory -DCOMPILER_ID=$<IF:$<BOOL:${WIN32}>,MSVC,GNU> -DLANGUAGE=CXX -DMODE=EXIST
+    ERROR_QUIET
+    RESULT_VARIABLE _EXIT_CODE
+    )
 
-if(NOT foonathan_memory_FOUND)
+if(NOT _EXIT_CODE EQUAL 0)
   ###############################################################################
   # Default shared libraries
   ###############################################################################
@@ -96,7 +100,7 @@ if(NOT foonathan_memory_FOUND)
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/foo_mem_ext_prj_install/
   DESTINATION ${CMAKE_INSTALL_PREFIX})
 else()
-  message(STATUS "Found foonathan_memory ${foonathan_memory_VERSION}")
+  message(STATUS "Found foonathan_memory")
 endif()
 
 configure_file(foonathan_memory_vendorConfig.cmake.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(foonathan_memory_vendor VERSION "1.3.1")
 
 execute_process(
-    COMMAND ${CMAKE_COMMAND} --find-package -DNAME=foonathan_memory -DCOMPILER_ID=$<IF:$<BOOL:${WIN32}>,MSVC,GNU> -DLANGUAGE=CXX -DMODE=EXIST
+    COMMAND ${CMAKE_COMMAND} --find-package -DNAME=foonathan_memory -DCOMPILER_ID=$<IF:$<BOOL:${WIN32}>,MSVC,GNU> -DLANGUAGE=CXX -DMODE=EXIST -DCMAKE_FIND_DEBUG_MODE=ON
     ERROR_QUIET
     RESULT_VARIABLE _EXIT_CODE
     )


### PR DESCRIPTION
With current implementation once foonathan_memory is compiled for a certain configuration (Release, Debug..) using colcon, changing to another compilation doesn't make it compile, because the previous one is found on CMAKE_INSTALL_PREFIX.

With new implemenation, this behaviour is fixed, but it is still be able to find an installed foonathan_memory.

Tested on Windows, Linux and Mac.